### PR TITLE
fix(useAsyncEffect): rethrow error raised in effect

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.OS }}-
 
     - name: Install dependencies ⏬
-      run: npm install
+      run: npm ci
 
     - name: Lint code 💄
       run: npm run lint

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -32,7 +32,7 @@ jobs:
           ${{ runner.OS }}-
 
     - name: Install dependencies ⏬
-      run: npm install
+      run: npm ci
 
     - name: Lint code 💄
       run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@terrestris/eslint-config-typescript": "^2.1.0",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^13.1.1",
-        "@testing-library/react-hooks": "^8.0.0",
         "@types/jest": "^27.0.3",
         "@types/react": "^18.0.8",
         "@types/react-dom": "^18.0.2",
@@ -3005,36 +3004,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
-      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
-          "optional": true
-        }
       }
     },
     "node_modules/@types/aria-query": {
@@ -12456,22 +12425,6 @@
         "react": "^18.1.0"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17029,16 +16982,6 @@
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "^18.0.0"
-      }
-    },
-    "@testing-library/react-hooks": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
-      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
       }
     },
     "@types/aria-query": {
@@ -24137,15 +24080,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.22.0"
-      }
-    },
-    "react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@terrestris/eslint-config-typescript": "^2.1.0",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^13.1.1",
-    "@testing-library/react-hooks": "^8.0.0",
     "@types/jest": "^27.0.3",
     "@types/react": "^18.0.8",
     "@types/react-dom": "^18.0.2",

--- a/src/hooks/useAsyncEffect/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect/useAsyncEffect.ts
@@ -11,32 +11,37 @@ type AsyncEffect = (options: AsyncEffectOptions) => Promise<void>;
 /**
  * This hook allows to use async functions as an effect.
  */
-export const useAsyncEffect = (effect: AsyncEffect, dependencies?: DependencyList) => {
-  useEffect(() => {
-    let mounted = true;
-    const cancelHandlers: (() => void)[] = [];
-    const abortController = new AbortController();
+export const useAsyncEffect = (effect: AsyncEffect, dependencies?: DependencyList): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    useEffect(() => {
+      let mounted = true;
+      const cancelHandlers: (() => void)[] = [];
+      const abortController = new AbortController();
 
-    const onCancel = (handler: () => void) => {
-      cancelHandlers.push(handler);
-    };
+      const onCancel = (handler: () => void) => {
+        cancelHandlers.push(handler);
+      };
 
-    const cleanup = () => {
-      mounted = false;
-      abortController.abort();
-      for (const cancelHandler of cancelHandlers) {
-        cancelHandler();
-      }
-    };
+      const cleanup = () => {
+        mounted = false;
+        abortController.abort();
+        for (const cancelHandler of cancelHandlers) {
+          cancelHandler();
+        }
+      };
 
-    effect({
-      isUnmounted: () => !mounted,
-      onUnmount: onCancel,
-      signal: abortController.signal
-    }).catch(() => {
-      cleanup();
-    });
+      effect({
+        isUnmounted: () => !mounted,
+        onUnmount: onCancel,
+        signal: abortController.signal
+      })
+        .then(resolve)
+        .catch((e) => {
+          cleanup();
+          reject(e);
+        });
 
-    return cleanup;
-  }, dependencies);
-}
+      return cleanup;
+    }, dependencies);
+  });
+};

--- a/src/hooks/useObjectState/useObjectState.spec.tsx
+++ b/src/hooks/useObjectState/useObjectState.spec.tsx
@@ -1,5 +1,5 @@
 import { useObjectState } from './useObjectState';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 
 import { Logger } from '@terrestris/base-util';
 


### PR DESCRIPTION
This PR fixes a problem of non reported errors in `useAsyncEffect`. If an error occurred inside the effect it was not appearing in the development console of the browser.

The hook now returns a promise that rejects if an error is thrown. If the error should not be handled the use should stay the same, this should be the normal use case.

```
useAsyncEffect(async () => { ... }) // now returns a promise
```

If the error is not handled via `.catch` it will be reported in the development console now.

It might be sub-optimal that the promise is ignored in normal use ... But if it is not returned it is not testable, because the error happens out of context.