### PR TITLE
feat: add support vor mapbox vector tiles

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.OS }}-
 
     - name: Install dependencies ⏬
-      run: npm ci
+      run: npm ci --force
 
     - name: Lint code 💄
       run: npm run lint

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -32,7 +32,7 @@ jobs:
           ${{ runner.OS }}-
 
     - name: Install dependencies ⏬
-      run: npm ci
+      run: npm ci --force
 
     - name: Lint code 💄
       run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "moment": "^2.29.4",
         "np": "^7.5.0",
         "ol": "^7.5.2",
+        "ol-mapbox-style": "^11.0.3",
         "prop-types": "^15.8.1",
         "react": "^18.0.0",
         "react-dom": "^18.1.0",
@@ -13977,6 +13978,19 @@
       }
     },
     "node_modules/ol-mapbox-style": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-11.0.3.tgz",
+      "integrity": "sha512-jc3PX1kHtvq8e5jPYVh9WFAppAbLrndik9qBicIemlQKPz0oFeQ98D3ITub3wfwVXXVReqeOKa43NGOseUne1Q==",
+      "dev": true,
+      "dependencies": {
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+        "mapbox-to-css-font": "^2.4.1"
+      },
+      "peerDependencies": {
+        "ol": ">=8.0.0 || >8.0.0-dev.0 < 8.0.0 || >=7.0.0 <=7.5.1"
+      }
+    },
+    "node_modules/ol/node_modules/ol-mapbox-style": {
       "version": "10.7.0",
       "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-10.7.0.tgz",
       "integrity": "sha512-S/UdYBuOjrotcR95Iq9AejGYbifKeZE85D9VtH11ryJLQPTZXZSW1J5bIXcr4AlAH6tyjPPHTK34AdkwB32Myw==",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "homepage": "https://github.com/terrestris/react-util#readme",
   "peerDependencies": {
+    "ol": ">=7",
     "react": ">=17",
-    "react-dom": ">=17",
-    "ol": ">=7"
+    "react-dom": ">=17"
   },
   "dependencies": {
     "@terrestris/base-util": "^1.0.1",
@@ -48,7 +48,6 @@
     "@babel/plugin-proposal-optional-chaining": "^7.13.12",
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.13.13",
-    "eslint-plugin-simple-import-sort": "^10.0.0",
     "@babel/preset-typescript": "^7.13.0",
     "@cfaester/enzyme-adapter-react-18": "^0.7.1",
     "@terrestris/eslint-config-typescript": "^3.0.0",
@@ -66,6 +65,7 @@
     "core-js": "^3.12.0",
     "enzyme": "^3.11.0",
     "eslint": "^8.14.0",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.6.4",
     "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.6.4",
@@ -75,6 +75,7 @@
     "moment": "^2.29.4",
     "np": "^7.5.0",
     "ol": "^7.5.2",
+    "ol-mapbox-style": "^11.0.3",
     "prop-types": "^15.8.1",
     "react": "^18.0.0",
     "react-dom": "^18.1.0",

--- a/src/BackgroundLayerChooser/BackgroundLayerChooser.tsx
+++ b/src/BackgroundLayerChooser/BackgroundLayerChooser.tsx
@@ -1,11 +1,13 @@
 import OlOverviewMap from 'ol/control/OverviewMap';
 import OlLayerBase from 'ol/layer/Base';
+import LayerGroup from 'ol/layer/Group';
 import OlLayerImage from 'ol/layer/Image';
 import OlLayer from 'ol/layer/Layer';
 import OlLayerTile from 'ol/layer/Tile';
 import { ObjectEvent } from 'ol/Object';
 import { getUid } from 'ol/util';
 import OlView from 'ol/View';
+import { apply as applyMapboxStyle } from 'ol-mapbox-style';
 import React, {
   useEffect,
   useRef,
@@ -88,6 +90,15 @@ export const BackgroundLayerChooser: React.FC<BackgroundLayerChooserProps> = ({
         ovLayer = new OlLayerImage({
           source: selectedLayer.getSource()
         });
+      } else if (selectedLayer instanceof LayerGroup) {
+        if (selectedLayer.get('isVectorTile')) {
+          ovLayer = new LayerGroup();
+          applyMapboxStyle(ovLayer, selectedLayer.get('url'));
+        } else {
+          ovLayer = new LayerGroup({
+            layers: selectedLayer.getLayers()
+          });
+        }
       }
       if (ovLayer && mapTarget.current) {
         const overViewControl = new OlOverviewMap({


### PR DESCRIPTION
Adds support for Mapbox vector tile layers in the background chooser. In case a `LayerGroup` layer is found which has the flag `isVectorTile` set to `true`, the group layer's `url` value is used to create a vector tile group layer for the preview/overview.

@terrestris/devs Please review.