### PR TITLE
Minor fix for the `useGeoLocation` hook

### DIFF
--- a/src/Hooks/useGeoLocation/useGeoLocation.ts
+++ b/src/Hooks/useGeoLocation/useGeoLocation.ts
@@ -73,8 +73,8 @@ export const useGeoLocation = ({
     }),
     style: (feature: OlFeature<OlGeometry> | RenderFeature) => {
       const heading = feature.get('heading');
-      const src = heading !== 0 ? mapMarkerHeading : mapMarker;
-      const rotation = heading !== 0 ? heading * Math.PI / 180 : 0;
+      const src = (Number.isFinite(heading) && heading !== 0) ? mapMarkerHeading : mapMarker;
+      const rotation = (Number.isFinite(heading) && heading !== 0) ? heading * Math.PI / 180 : 0;
 
       return [new OlStyleStyle({
         image: new OlStyleIcon({
@@ -83,7 +83,7 @@ export const useGeoLocation = ({
         })
       })];
     }
-  }), [], showMarker);
+  }), [], showMarker && active);
 
   /**
    * Callback of the interactions on change event.


### PR DESCRIPTION
Hide the marker layer depending on the `active` status and add a `NaN` check in the style function.

Please review @terrestris/devs.