### PR TITLE
Restore expected dist contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run clean && npm run build:dist && npm run build:declaration && copyfiles src/**/*.png dist/ && rimraf ./dist/test",
+    "build": "npm run clean && npm run build:dist && npm run build:declaration && copyfiles src/**/*.png dist/ && mv ./dist/src/** ./dist && rimraf ./dist/test ./dist/src",
     "build:declaration": "tsc --emitDeclarationOnly",
     "build:dist": "tsc -p tsconfig.json",
     "clean": "rimraf ./coverage/* ./dist/*",


### PR DESCRIPTION
Due to the changed `root` dir in #500, the contents of the `dist` directory included a `src` subdirectory. This restores the expected contents without the `src` directory.

Please review @terrestris/devs.