### PR TITLE
Feature: introduce useWfs hook

### DIFF
--- a/src/Hooks/useWfs/useWfs.spec.ts
+++ b/src/Hooks/useWfs/useWfs.spec.ts
@@ -1,0 +1,9 @@
+import { useWfs } from './useWfs';
+
+jest.mock('react');
+
+describe('basic test', () => {
+  it('is defined', () => {
+    expect(useWfs).toBeDefined();
+  });
+});

--- a/src/Hooks/useWfs/useWfs.ts
+++ b/src/Hooks/useWfs/useWfs.ts
@@ -34,10 +34,10 @@ export const useWfs = ({
   const [loading, setLoading] = useState<boolean>(false);
 
   /**
-   * Perform the search.
+   * Perform the WFS request.
    * @private
    */
-  const doSearch = async () => {
+  const performWfsRequest = async () => {
     const request = WfsFilterUtil.getCombinedRequests(searchConfig, searchTerm);
     const requestBody = (new XMLSerializer()).serializeToString(request);
     if (!_isNil(request)) {
@@ -74,7 +74,7 @@ export const useWfs = ({
 
   useAsyncEffect(async () => {
     if (!_isNil(searchTerm) && searchTerm.length >= minChars) {
-      await doSearch();
+      await performWfsRequest();
     } else {
       setFeatures([]);
       setLoading(false);

--- a/src/Hooks/useWfs/useWfs.ts
+++ b/src/Hooks/useWfs/useWfs.ts
@@ -1,0 +1,86 @@
+import WfsFilterUtil, { SearchConfig } from '@terrestris/ol-util/dist/WfsFilterUtil/WfsFilterUtil';
+import _isNil from 'lodash/isNil';
+import OlFeature from 'ol/Feature';
+import OlFormatGeoJSON from 'ol/format/GeoJSON';
+import OlFormatGml3 from 'ol/format/GML3';
+import { useState } from 'react';
+
+import { useAsyncEffect } from '../../index';
+
+export type WfsQueryArgs = {
+  additionalFetchOptions?: Partial<RequestInit>;
+  baseUrl: string;
+  minChars?: number;
+  onFetchError?: (s: any) => void;
+  searchConfig: SearchConfig;
+  searchTerm?: string;
+};
+
+export type WfsResponse = {
+  features: OlFeature[] | undefined;
+  loading: boolean;
+};
+
+export const useWfs = ({
+  additionalFetchOptions = {},
+  baseUrl,
+  minChars = 3,
+  onFetchError = () => undefined,
+  searchTerm,
+  searchConfig
+}: WfsQueryArgs): WfsResponse => {
+
+  const [features, setFeatures] = useState<OlFeature[] | undefined>();
+  const [loading, setLoading] = useState<boolean>(false);
+
+  /**
+   * Perform the search.
+   * @private
+   */
+  const doSearch = async () => {
+    const request = WfsFilterUtil.getCombinedRequests(searchConfig, searchTerm);
+    const requestBody = (new XMLSerializer()).serializeToString(request);
+    if (!_isNil(request)) {
+      setLoading(true);
+      const responseString = await fetch(`${baseUrl}`, {
+        method: 'POST',
+        credentials: additionalFetchOptions?.credentials ?? 'same-origin',
+        body: requestBody,
+        ...additionalFetchOptions
+      }).then(response => response.text());
+
+      let ff: OlFeature[];
+      if (searchConfig?.outputFormat?.indexOf('json')) {
+        const json = JSON.parse(responseString);
+        const format = new OlFormatGeoJSON({
+          featureProjection: searchConfig?.srsName,
+          dataProjection: searchConfig?.srsName,
+        });
+        ff = format.readFeatures(json);
+      } else {
+        const format = new OlFormatGml3({
+          featureNS: searchConfig?.featureNS,
+          srsName: searchConfig?.srsName
+        });
+        ff = format.readFeatures(responseString);
+      }
+      setLoading(false);
+      setFeatures(ff);
+    } else {
+      onFetchError('Missing GetFeature request parameters');
+      setLoading(false);
+    }
+  };
+
+  useAsyncEffect(async () => {
+    if (!_isNil(searchTerm) && searchTerm.length >= minChars) {
+      await doSearch();
+    }
+  }, [searchTerm]);
+
+  return {
+    loading,
+    features
+  };
+
+};

--- a/src/Hooks/useWfs/useWfs.ts
+++ b/src/Hooks/useWfs/useWfs.ts
@@ -1,3 +1,4 @@
+import Logger from '@terrestris/base-util/dist/Logger';
 import WfsFilterUtil, { SearchConfig } from '@terrestris/ol-util/dist/WfsFilterUtil/WfsFilterUtil';
 import _isNil from 'lodash/isNil';
 import OlFeature from 'ol/Feature';
@@ -6,7 +7,6 @@ import OlFormatGml3 from 'ol/format/GML3';
 import { useState } from 'react';
 
 import { useAsyncEffect } from '../../index';
-import Logger from '@terrestris/base-util/dist/Logger';
 
 export type WfsQueryArgs = {
   additionalFetchOptions?: Partial<RequestInit>;

--- a/src/Hooks/useWfs/useWfs.ts
+++ b/src/Hooks/useWfs/useWfs.ts
@@ -6,13 +6,14 @@ import OlFormatGml3 from 'ol/format/GML3';
 import { useState } from 'react';
 
 import { useAsyncEffect } from '../../index';
+import Logger from "@terrestris/base-util/dist/Logger";
 
 export type WfsQueryArgs = {
   additionalFetchOptions?: Partial<RequestInit>;
   baseUrl: string;
   minChars?: number;
   onFetchError?: (s: any) => void;
-  searchConfig: SearchConfig;
+  searchConfig?: SearchConfig;
   searchTerm?: string;
 };
 
@@ -38,6 +39,10 @@ export const useWfs = ({
    * @private
    */
   const performWfsRequest = async () => {
+    if (_isNil(searchConfig)) {
+      Logger.error('No search configuration given.');
+      return;
+    }
     const request = WfsFilterUtil.getCombinedRequests(searchConfig, searchTerm);
     const requestBody = (new XMLSerializer()).serializeToString(request);
     if (!_isNil(request)) {

--- a/src/Hooks/useWfs/useWfs.ts
+++ b/src/Hooks/useWfs/useWfs.ts
@@ -6,7 +6,7 @@ import OlFormatGml3 from 'ol/format/GML3';
 import { useState } from 'react';
 
 import { useAsyncEffect } from '../../index';
-import Logger from "@terrestris/base-util/dist/Logger";
+import Logger from '@terrestris/base-util/dist/Logger';
 
 export type WfsQueryArgs = {
   additionalFetchOptions?: Partial<RequestInit>;

--- a/src/Hooks/useWfs/useWfs.ts
+++ b/src/Hooks/useWfs/useWfs.ts
@@ -75,6 +75,9 @@ export const useWfs = ({
   useAsyncEffect(async () => {
     if (!_isNil(searchTerm) && searchTerm.length >= minChars) {
       await doSearch();
+    } else {
+      setFeatures([]);
+      setLoading(false);
     }
   }, [searchTerm]);
 


### PR DESCRIPTION
This PR introduces a hook `useWfs`  wich can be used to perform a WFS `GetFeature` query (WFS version 1.1.0 is currently only supported, see also `WfsFilterUtil` in https://github.com/terrestris/ol-util).

Plz review @terrestris/devs 