### PR TITLE
Update peerDependencies and ol-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "watch": "^1.0.2"
   },
   "peerDependencies": {
-    "@terrestris/ol-util": ">=15",
-    "ol": ">=8.2.0",
+    "@terrestris/ol-util": ">=16",
+    "ol": ">=9",
     "ol-mapbox-style": ">=12",
     "react": ">=18",
     "react-dom": ">=18"


### PR DESCRIPTION
This MR updates the peerDependencies for `ol` and `ol-util`. It is currently a draft, because the library has to use [new ol-util version](https://github.com/terrestris/ol-util/pull/1359). The updated package-lock.json must then be added!