### PR TITLE
Adds the onSuccess callback to useCoordinateinfo

### DIFF
--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -113,10 +113,15 @@ export const useCoordinateInfo = ({
       });
       setFeatures(featureMap);
       setClickCoordinate(coordinate);
+
+      // We're cloning the click coordinate and features to
+      // not pass the internal state reference to the parent component.
+      // Also note that we explicitly don't use feature.clone() to
+      // keep all feature properties (in particular the id) intact.
       onSuccess({
-        clickCoordinate: _cloneDeep(clickCoordinate),
+        clickCoordinate: _cloneDeep(coordinate),
         loading,
-        features: _cloneDeep(features)
+        features: _cloneDeep(featureMap)
       });
 
     } catch (error: any) {

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -34,6 +34,7 @@ export type UseCoordinateInfoArgs = {
     [uid: string]: RequestInit;
   } | ((layer: WmsLayer) => RequestInit);
   onError?: (error: any) => void;
+  onSuccess?: (result: CoordinateInfoResult) => void;
   queryLayers?: OlBaseLayer[];
 };
 
@@ -42,7 +43,8 @@ export const useCoordinateInfo = ({
   featureCount = 1,
   fetchOpts = {},
   drillDown = false,
-  onError = () => {}
+  onError = () => {},
+  onSuccess = () => {}
 }: UseCoordinateInfoArgs): CoordinateInfoResult => {
 
   const map = useMap();
@@ -111,6 +113,11 @@ export const useCoordinateInfo = ({
       });
       setFeatures(featureMap);
       setClickCoordinate(coordinate);
+      onSuccess({
+        clickCoordinate: _cloneDeep(clickCoordinate),
+        loading,
+        features: _cloneDeep(features)
+      });
 
     } catch (error: any) {
       Logger.error(error);


### PR DESCRIPTION
This adds an `onSuccess` property to the `useCoordinateInfo` hook.

@terrestris/devs please review