### PR TITLE
fix: remove functions from dependency lists that normally change on every render

### DIFF
--- a/src/Hooks/search/useSearch/useSearch.ts
+++ b/src/Hooks/search/useSearch/useSearch.ts
@@ -30,8 +30,8 @@ export const useSearch = <
     {
       minChars = 3,
       debounceTime = 100,
-      onFetchError = () => {},
-      onFetchSuccess = () => {}
+      onFetchError,
+      onFetchSuccess
     }: SearchOptions<G, T, C>
   ) => {
   const [featureCollection, setFeatureCollection] = useState<C>();
@@ -45,9 +45,9 @@ export const useSearch = <
         try {
           const collection = await searchFunction(searchTerm);
           setFeatureCollection(collection);
-          onFetchSuccess(collection);
+          onFetchSuccess?.(collection);
         } catch (error) {
-          onFetchError(error);
+          onFetchError?.(error);
         } finally {
           setLoading(false);
         }
@@ -63,7 +63,8 @@ export const useSearch = <
 
       return undefined;
     }
-  }, [debounceTime, minChars, onFetchError, onFetchSuccess, searchFunction, searchTerm]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debounceTime, minChars, searchFunction, searchTerm]);
 
   return {
     loading,

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -58,8 +58,8 @@ export const useCoordinateInfo = ({
   featureCount = 1,
   fetchOpts = {},
   drillDown = false,
-  onError = () => { },
-  onSuccess = () => { },
+  onError,
+  onSuccess,
   infoFormat = 'gml'
 }: UseCoordinateInfoArgs): CoordinateInfoResult => {
 
@@ -166,7 +166,7 @@ export const useCoordinateInfo = ({
       // not pass the internal state reference to the parent component.
       // Also note that we explicitly don't use feature.clone() to
       // keep all feature properties (in particular the id) intact.
-      onSuccess({
+      onSuccess?.({
         clickCoordinate: _cloneDeep(coordinate),
         loading,
         features: _cloneDeep(results)
@@ -174,12 +174,13 @@ export const useCoordinateInfo = ({
 
     } catch (error: any) {
       Logger.error(error);
-      onError(error);
+      onError?.(error);
     }
     map.getTargetElement().style.cursor = '';
     setLoading(false);
 
-  }, [drillDown, featureCount, fetchOpts, infoFormat, layerFilter, loading, map, onError, onSuccess]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [drillDown, featureCount, fetchOpts, infoFormat, layerFilter, loading, map]);
 
   useEffect(() => {
     map?.on('click', onMapClick);

--- a/src/Hooks/useOlInteraction/useOlInteraction.ts
+++ b/src/Hooks/useOlInteraction/useOlInteraction.ts
@@ -46,7 +46,7 @@ export const useOlInteraction = <InteractionType extends Interaction> (
       setInteraction(undefined);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...dependencies, map, constructor]);
+  }, [...dependencies, map]);
 
   useEffect(() => {
     if (!interaction || isNil(active)) {

--- a/src/Hooks/useOlLayer/useOlLayer.ts
+++ b/src/Hooks/useOlLayer/useOlLayer.ts
@@ -44,7 +44,7 @@ export const useOlLayer = <LayerType extends BaseLayer>(
       setLayer(undefined);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, constructor, ...dependencies]);
+  }, [map, ...dependencies]);
 
   useEffect(() => {
     if (!layer || isNil(visible)) {

--- a/src/Util/rtlTestUtils.tsx
+++ b/src/Util/rtlTestUtils.tsx
@@ -103,7 +103,7 @@ export function renderInMapContext(map: OlMap, element: ReactElement, size: [num
 
   const { rerender, ...results } = render(assemble(element));
 
-  map.setSize([400, 400]);
+  map.setSize(size);
   map.renderSync();
 
   const rerenderInMapContext = (newElement: ReactElement) => {


### PR DESCRIPTION
If we want to use, for example, useOlLayer like this:
```
const layer = useOlLayer(() => new OlLayerVector({}), []);
```
we need to exclude the constructor function from any dependency list as the function will be recreated on every render.
These are intended to be used without a wrap into `useCallback` and are reevaluated if the dependencies of the `useOlLayer` hook change.

There are als callback functions that gets passed in from parent components via props.
For example something like `onSuccess`. If we include these into dependency lists, we can't do the following:
```
<Component
  onSuccess={() => do something}
  />
```

I think this is done similarly in libraries like antd where these patterns are used regularly.

Otherwise we would need to wrap every callback into a useCallback. Which would not be a good practice but would require some work and also differs from the behavior of the libraries.