### PR TITLE
fix: cleanup tooltips also when the containing component gets removed

### DIFF
--- a/src/Hooks/useMeasure/useMeasure.ts
+++ b/src/Hooks/useMeasure/useMeasure.ts
@@ -217,7 +217,7 @@ export const useMeasure = ({
   const removeMeasureTooltip = useCallback(() => {
     if (map && measureTooltip.current) {
       map.removeOverlay(measureTooltip.current);
-      measureTooltip.current = undefined
+      measureTooltip.current = undefined;
     }
   }, [map]);
 


### PR DESCRIPTION
before:

![Peek 2024-06-11 15-45](https://github.com/terrestris/react-util/assets/8100558/60b81aa8-3c28-45e0-b2ea-a278004a7063)

after:

![Peek 2024-06-11 15-42](https://github.com/terrestris/react-util/assets/8100558/056e92d6-0060-49af-acb2-9f2754b2a92b)
