### PR TITLE
fix: propagate state from useCoordinateInfo

### DIFF
--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -139,7 +139,7 @@ export const useCoordinateInfo = ({
           } else if (infoFormat === 'json') {
             format = new OlFormatGeoJSON();
           } else {
-            return;
+            continue;
           }
 
           const text = await response.text();

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -1,6 +1,6 @@
 import Logger from '@terrestris/base-util/dist/Logger';
 import { isWfsLayer, isWmsLayer, WfsLayer, WmsLayer } from '@terrestris/ol-util';
-import { isString, uniqueId } from 'lodash';
+import { cloneDeep, isString, uniqueId } from 'lodash';
 import _isNil from 'lodash/isNil';
 import { Coordinate as OlCoordinate } from 'ol/coordinate';
 import OlFeature from 'ol/Feature';
@@ -167,15 +167,20 @@ export const useCoordinateInfo = ({
           featureType: getFeatureType(f)
         })));
       }
-      setFeatureResults(results);
-      setClickCoordinate(coordinate);
 
-      // We can actually propagate the state variable here. It should
-      // not be altered in another component.
+      // We're cloning the click coordinate and features to be able
+      // to alter the features without affecting the original ones
+      // Also note that we explicitly don't use feature.clone() to
+      // keep all feature properties (in particular the id) intact.
+      const clonedResults = cloneDeep(results);
+      const clonedCoordinate = cloneDeep(coordinate);
+      setFeatureResults(clonedResults);
+      setClickCoordinate(clonedCoordinate);
+
       onSuccess?.({
-        clickCoordinate: coordinate,
+        clickCoordinate: clonedCoordinate,
         loading: false,
-        features: results
+        features: clonedResults
       });
 
     } catch (error: any) {

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -1,7 +1,6 @@
 import Logger from '@terrestris/base-util/dist/Logger';
 import { isWfsLayer, isWmsLayer, WfsLayer, WmsLayer } from '@terrestris/ol-util';
 import { isString, uniqueId } from 'lodash';
-import _cloneDeep from 'lodash/cloneDeep';
 import _isNil from 'lodash/isNil';
 import { Coordinate as OlCoordinate } from 'ol/coordinate';
 import OlFeature from 'ol/Feature';
@@ -171,14 +170,12 @@ export const useCoordinateInfo = ({
       setFeatureResults(results);
       setClickCoordinate(coordinate);
 
-      // We're cloning the click coordinate and features to
-      // not pass the internal state reference to the parent component.
-      // Also note that we explicitly don't use feature.clone() to
-      // keep all feature properties (in particular the id) intact.
+      // We can actually propagate the state variable here. It should
+      // not be altered in another component.
       onSuccess?.({
-        clickCoordinate: _cloneDeep(coordinate),
+        clickCoordinate: coordinate,
         loading: false,
-        features: _cloneDeep(results)
+        features: results
       });
 
     } catch (error: any) {
@@ -198,10 +195,12 @@ export const useCoordinateInfo = ({
     };
   }, [map, onMapClick]);
 
+  // We want to propagate the state here so the variables do
+  // not change on every render cycle.
   return {
-    clickCoordinate: _cloneDeep(clickCoordinate),
+    clickCoordinate,
     loading,
-    features: _cloneDeep(featureResults)
+    features: featureResults
   };
 };
 


### PR DESCRIPTION
We should propagate the state out of the `useCoordinateInfo` so it does not change on every render step.