### PR TITLE
Add configurable GML version selection with fallback mechanism

### DIFF
--- a/src/Hooks/search/createWfsSearchFunction.ts
+++ b/src/Hooks/search/createWfsSearchFunction.ts
@@ -3,16 +3,50 @@ import {
 } from 'geojson';
 import _isNil from 'lodash/isNil';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
+import OlFormatGml2 from 'ol/format/GML2';
 import OlFormatGml3 from 'ol/format/GML3';
+import OlFormatGml32 from 'ol/format/GML32';
 
-import WfsFilterUtil, { SearchConfig } from '@terrestris/ol-util/dist/WfsFilterUtil/WfsFilterUtil';
+import logger from '@terrestris/base-util/dist/Logger';
+import WfsFilterUtil, {
+  SearchConfig
+} from '@terrestris/ol-util/dist/WfsFilterUtil/WfsFilterUtil';
 
 import { SearchFunction } from './useSearch/useSearch';
+
+export type GmlVersion = 'GML2' | 'GML3' | 'GML32';
 
 export type WfsArgs = {
   additionalFetchOptions?: Partial<RequestInit>;
   baseUrl: string;
-} & Omit<SearchConfig, 'olFilterOnly'|'filter'|'wfsFormatOptions'>;
+  gmlVersion?: GmlVersion;
+} & Omit<SearchConfig, 'olFilterOnly' | 'filter' | 'wfsFormatOptions'>;
+
+const createGmlFormat = (
+  version: GmlVersion,
+  featureNS: string,
+  srsName: string
+) => {
+  switch (version) {
+    case 'GML32':
+      return new OlFormatGml32({
+        featureNS,
+        srsName
+      });
+    case 'GML3':
+      return new OlFormatGml3({
+        featureNS,
+        srsName
+      });
+    case 'GML2':
+      return new OlFormatGml2({
+        featureNS,
+        srsName
+      });
+    default:
+      throw new Error(`Unsupported GML version: ${version}`);
+  }
+};
 
 export const createWfsSearchFunction = <
   G extends Geometry = Geometry,
@@ -29,21 +63,24 @@ export const createWfsSearchFunction = <
     outputFormat = 'application/json',
     srsName = 'EPSG:4326',
     attributeDetails,
-    propertyNames
+    propertyNames,
+    gmlVersion
   }: WfsArgs): SearchFunction<G, T, C> => {
-
   return async searchTerm => {
-    const request = WfsFilterUtil.getCombinedRequests({
-      featureNS,
-      featurePrefix,
-      featureTypes,
-      geometryName,
-      maxFeatures,
-      outputFormat,
-      srsName,
-      attributeDetails,
-      propertyNames
-    }, searchTerm) as Element;
+    const request = WfsFilterUtil.getCombinedRequests(
+      {
+        featureNS,
+        featurePrefix,
+        featureTypes,
+        geometryName,
+        maxFeatures,
+        outputFormat,
+        srsName,
+        attributeDetails,
+        propertyNames
+      },
+      searchTerm
+    ) as Element;
     const requestBody = (new XMLSerializer()).serializeToString(request);
     if (!_isNil(request)) {
       const response = await fetch(`${baseUrl}`, {
@@ -57,17 +94,29 @@ export const createWfsSearchFunction = <
         return response.json() as unknown as C;
       } else {
         const responseString = await response.text();
-
-        const formatGml = new OlFormatGml3({
-          featureNS,
-          srsName
-        });
-
         const formatGeoJson = new OlFormatGeoJSON();
-        return formatGeoJson.writeFeaturesObject(formatGml.readFeatures(responseString)) as C;
+
+        if (gmlVersion) {
+          const formatGml = createGmlFormat(gmlVersion, featureNS, srsName);
+          return formatGeoJson.writeFeaturesObject(
+            formatGml.readFeatures(responseString)
+          ) as C;
+        }
+
+        const gmlVersions: GmlVersion[] = ['GML32', 'GML3', 'GML2'];
+        for (const version of gmlVersions) {
+          try {
+            const formatGml = createGmlFormat(version, featureNS, srsName);
+            const features = formatGml.readFeatures(responseString);
+            if (features.length > 0) {
+              return formatGeoJson.writeFeaturesObject(features) as C;
+            }
+          } catch (error) {
+            logger.warn(`Error parsing WFS response with ${version}:`, error);
+          }
+        }
       }
-    } else {
-      throw new Error('WFS request is empty/null');
     }
+    throw new Error('Failed to fetch WFS data');
   };
 };


### PR DESCRIPTION
This MR introduces the ability to configure the GML version for WFS responses in `createWfsSearchFunction` and implements a fallback mechanism in case the specified version doesn't return valid features.

If `gmlVersion` is not provided in `createWfsSearchFunction`, the function now tries [GML32](https://openlayers.org/en/latest/apidoc/module-ol_format_GML32-GML32.html), then [GML3](https://openlayers.org/en/latest/apidoc/module-ol_format_GML3-GML3.html), and finally [GML2](https://openlayers.org/en/latest/apidoc/module-ol_format_GML2-GML2.html), stopping at the first successful result.

@terrestris/devs please review