### PR TITLE
feat(coodinateInfo): adds pointerrest and functions for layerfilter and infoFormat

### DIFF
--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.spec.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.spec.ts
@@ -2,8 +2,10 @@ import { useCoordinateInfo } from './useCoordinateInfo';
 
 jest.mock('react');
 
-describe('basic test', () => {
+describe('useCoordinateInfo', () => {
+
   it('is defined', () => {
     expect(useCoordinateInfo).toBeDefined();
   });
+
 });

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -57,7 +57,7 @@ export interface UseCoordinateInfoArgs {
 }
 
 const getFeatureType = (feature: OlFeature) => {
-  const id = feature.getId();
+  const id = feature.getId() ?? feature.get('id');
   return isString(id) ? id.split('.')[0] : id?.toString() ?? uniqueId('UNKNOWN');
 };
 

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -14,6 +14,7 @@ import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import OlFormatGML2 from 'ol/format/GML2';
 import OlFormatGml3 from 'ol/format/GML3';
 import OlFormatGml32 from 'ol/format/GML32';
+import OlFormatWMSGetFeatureInfo from 'ol/format/WMSGetFeatureInfo';
 import OlLayer from 'ol/layer/Layer';
 import OlMapBrowserEvent from 'ol/MapBrowserEvent';
 import { Pixel as OlPixel } from 'ol/pixel';
@@ -157,10 +158,13 @@ export const useCoordinateInfo = ({
               opts = fetchOpts[getUid(layer)];
             }
             const response = await fetch(featureInfoUrl, opts);
-            let format: OlFormatGML2 | OlFormatGml3 | OlFormatGml32 | OlFormatGeoJSON | null = null;
+            let format: OlFormatGML2 | OlFormatGml3 | OlFormatGml32 |
+              OlFormatGeoJSON | OlFormatWMSGetFeatureInfo | null = null;
 
             let isJson = false;
             if (infoFormat === 'application/vnd.ogc.gml') {
+              format = new OlFormatWMSGetFeatureInfo();
+            } else if (infoFormat.indexOf('gml/2') > -1) {
               format = new OlFormatGML2();
             } else if (infoFormat === 'application/vnd.ogc.gml/3.1.1' || infoFormat === 'text/xml; subtype=gml/3.1.1') {
               format = new OlFormatGml3();

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -36,6 +36,7 @@ export interface FeatureLayerResult {
 
 export interface CoordinateInfoResult {
   clickCoordinate: OlCoordinate | null;
+  pixelCoordinate: [number, number] | null;
   features: FeatureLayerResult[];
   loading: boolean;
 }
@@ -76,6 +77,7 @@ export const useCoordinateInfo = ({
   const map = useMap();
 
   const [clickCoordinate, setClickCoordinate] = useState<OlCoordinate | null>(null);
+  const [pixelCoordinate, setPixelCoordinate] = useState<[number, number] | null>(null);
   const [featureResults, setFeatureResults] = useState<FeatureLayerResult[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -113,6 +115,7 @@ export const useCoordinateInfo = ({
     const viewProjection = mapView.getProjection();
     const pixel = map.getEventPixel(olEvt.originalEvent);
     const coordinate = olEvt.coordinate;
+    const evtPixelCoordinate: [number, number] = [olEvt.originalEvent.x, olEvt.originalEvent.y];
 
     const wmsMapLayers =
       map.getAllLayers()
@@ -212,11 +215,14 @@ export const useCoordinateInfo = ({
       // keep all feature properties (in particular the id) intact.
       const clonedResults = cloneDeep(results);
       const clonedCoordinate = cloneDeep(coordinate);
+      const clonedPixelCoordinate = cloneDeep(evtPixelCoordinate);
       setFeatureResults(clonedResults);
       setClickCoordinate(clonedCoordinate);
+      setPixelCoordinate(clonedPixelCoordinate);
 
       onSuccess?.({
         clickCoordinate: clonedCoordinate,
+        pixelCoordinate: clonedPixelCoordinate,
         loading: false,
         features: clonedResults
       });
@@ -270,8 +276,9 @@ export const useCoordinateInfo = ({
   // not change on every render cycle.
   return {
     clickCoordinate,
+    features: featureResults,
     loading,
-    features: featureResults
+    pixelCoordinate
   };
 };
 

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -8,11 +8,16 @@ import {
 
 import _isNil from 'lodash/isNil';
 import { Coordinate as OlCoordinate } from 'ol/coordinate';
+import { EventsKey } from 'ol/events';
 import OlFeature from 'ol/Feature';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import OlFormatGML2 from 'ol/format/GML2';
-import OlBaseLayer from 'ol/layer/Base';
+import OlFormatGml3 from 'ol/format/GML3';
+import OlFormatGml32 from 'ol/format/GML32';
+import OlLayer from 'ol/layer/Layer';
 import OlMapBrowserEvent from 'ol/MapBrowserEvent';
+import { Pixel as OlPixel } from 'ol/pixel';
+import OlSource from 'ol/source/Source';
 import { getUid } from 'ol/util';
 
 import Logger from '@terrestris/base-util/dist/Logger';
@@ -35,24 +40,18 @@ export interface CoordinateInfoResult {
 }
 
 export interface UseCoordinateInfoArgs {
+  active: boolean;
   drillDown?: boolean;
   featureCount?: number;
   fetchOpts?: Record<string, RequestInit> | ((layer: WmsLayer) => RequestInit);
+  getInfoFormat?: (layer: WmsLayer) => string | Promise<string>;
+  layerFilter?: (layerCandidate: OlLayer<OlSource>) => boolean;
   onError?: (error: any) => void;
   onSuccess?: (result: CoordinateInfoResult) => void;
-  queryLayers?: OlBaseLayer[];
-  infoFormat?: 'gml'|'json';
+  registerOnClick?: boolean;
+  registerOnPointerMove?: boolean;
+  registerOnPointerRest?: boolean;
 }
-
-const getInfoFormat = (type: 'gml'|'json') => {
-  if (type === 'gml') {
-    return 'application/vnd.ogc.gml';
-  } else if (type === 'json') {
-    return 'application/json';
-  } else {
-    throw new Error('Unknown info format type');
-  }
-};
 
 const getFeatureType = (feature: OlFeature) => {
   const id = feature.getId();
@@ -60,24 +59,24 @@ const getFeatureType = (feature: OlFeature) => {
 };
 
 export const useCoordinateInfo = ({
-  queryLayers = [],
+  active,
+  drillDown = false,
   featureCount = 1,
   fetchOpts = {},
-  drillDown = false,
-  onError,
-  onSuccess,
-  infoFormat = 'gml'
+  getInfoFormat = () => 'application/json',
+  layerFilter = () => true,
+  onError = () => undefined,
+  onSuccess = () => undefined,
+  registerOnClick = true,
+  registerOnPointerMove = false,
+  registerOnPointerRest = false
 }: UseCoordinateInfoArgs): CoordinateInfoResult => {
 
   const map = useMap();
 
-  const [clickCoordinate, setClickCoordinate] = useState<any>();
+  const [clickCoordinate, setClickCoordinate] = useState<OlCoordinate | null>(null);
   const [featureResults, setFeatureResults] = useState<FeatureLayerResult[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
-
-  const layerFilter = useCallback((layerCandidate: OlBaseLayer): boolean => {
-    return queryLayers.includes(layerCandidate);
-  }, [queryLayers]);
 
   useEffect(() => {
     if (map && loading) {
@@ -89,7 +88,22 @@ export const useCoordinateInfo = ({
     return undefined;
   }, [loading, map]);
 
-  const onMapClick = useCallback(async (olEvt: OlMapBrowserEvent<MouseEvent>) => {
+  const onPointerMove = useCallback((olEvt: OlMapBrowserEvent<MouseEvent>) => {
+    if (olEvt.dragging || _isNil(map)) {
+      return;
+    }
+
+    const pixel: OlPixel = map.getEventPixel(olEvt.originalEvent);
+    const hits = map.getAllLayers()
+      .filter(l => layerFilter(l))
+      .filter(l => {
+        const pixelData: any = l.getData(pixel);
+        return pixelData && pixelData[3] > 0;
+      });
+    map.getTargetElement().style.cursor = hits?.length > 0 ? 'pointer' : '';
+  }, [layerFilter, map]);
+
+  const handleMapEvent = useCallback(async (olEvt: OlMapBrowserEvent<MouseEvent>) => {
     if (_isNil(map)) {
       return;
     }
@@ -101,11 +115,13 @@ export const useCoordinateInfo = ({
 
     const wmsMapLayers =
       map.getAllLayers()
+        .reverse()
         .filter(layerFilter)
         .filter(l => l.getData && l.getData(pixel) && isWmsLayer(l)) as WmsLayer[];
 
     const wfsMapLayers =
       map.getAllLayers()
+        .reverse()
         .filter(layerFilter)
         .filter(l => isWfsLayer(l)) as WfsLayer[];
 
@@ -115,47 +131,58 @@ export const useCoordinateInfo = ({
       const results: FeatureLayerResult[] = [];
 
       for (const layer of wmsMapLayers) {
-        if (!drillDown && results.length > 0) {
-          break;
-        }
-        const wmsLayerSource = layer.getSource();
-        if (!wmsLayerSource) {
-          continue;
-        }
-        const featureInfoUrl = wmsLayerSource.getFeatureInfoUrl(
-          coordinate,
+        try {
+          if (!drillDown && results.length > 0) {
+            break;
+          }
+          const wmsLayerSource = layer.getSource();
+          if (!wmsLayerSource) {
+            continue;
+          }
+          const infoFormat = await getInfoFormat(layer);
+          const featureInfoUrl = wmsLayerSource.getFeatureInfoUrl(
+            coordinate,
           viewResolution!,
           viewProjection,
           {
-            INFO_FORMAT: getInfoFormat(infoFormat),
+            INFO_FORMAT: infoFormat,
             FEATURE_COUNT: featureCount
           }
-        );
-        if (featureInfoUrl) {
-          let opts;
-          if (fetchOpts instanceof Function) {
-            opts = fetchOpts(layer as WmsLayer);
-          } else {
-            opts = fetchOpts[getUid(layer)];
+          );
+          if (featureInfoUrl) {
+            let opts;
+            if (fetchOpts instanceof Function) {
+              opts = fetchOpts(layer as WmsLayer);
+            } else {
+              opts = fetchOpts[getUid(layer)];
+            }
+            const response = await fetch(featureInfoUrl, opts);
+            let format: OlFormatGML2 | OlFormatGml3 | OlFormatGml32 | OlFormatGeoJSON | null = null;
+
+            let isJson = false;
+            if (infoFormat === 'application/vnd.ogc.gml') {
+              format = new OlFormatGML2();
+            } else if (infoFormat === 'application/vnd.ogc.gml/3.1.1' || infoFormat === 'text/xml; subtype=gml/3.1.1') {
+              format = new OlFormatGml3();
+            } else if (infoFormat === 'application/vnd.ogc.gml/3.2' || infoFormat === 'text/xml; subtype=gml/3.2') {
+              format = new OlFormatGml32();
+            } else if (infoFormat === 'application/json' || infoFormat.indexOf('json') > -1) {
+              format = new OlFormatGeoJSON();
+              isJson = true;
+            } else {
+              continue;
+            }
+
+            const text = isJson ? await response.json() : await response.text();
+
+            results.push(...format.readFeatures(text).map(f => ({
+              feature: f,
+              layer,
+              featureType: getFeatureType(f)
+            })));
           }
-          const response = await fetch(featureInfoUrl, opts);
-          let format: OlFormatGML2 | OlFormatGeoJSON | null = null;
-
-          if (infoFormat === 'gml') {
-            format = new OlFormatGML2();
-          } else if (infoFormat === 'json') {
-            format = new OlFormatGeoJSON();
-          } else {
-            continue;
-          }
-
-          const text = await response.text();
-
-          results.push(...format.readFeatures(text).map(f => ({
-            feature: f,
-            layer,
-            featureType: getFeatureType(f)
-          })));
+        } catch (error: any) {
+          Logger.error(error);
         }
       }
       for (const layer of wfsMapLayers) {
@@ -196,16 +223,44 @@ export const useCoordinateInfo = ({
     }
     setLoading(false);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [drillDown, featureCount, fetchOpts, infoFormat, layerFilter, map]);
+  }, [drillDown, featureCount, fetchOpts, getInfoFormat, layerFilter, map, onError, onSuccess]);
 
   useEffect(() => {
-    map?.on('click', onMapClick);
+    let keyMove: EventsKey | undefined;
+    let keyRest: EventsKey | undefined;
+    let keyClick: EventsKey | undefined;
+    if (active) {
+      if (registerOnClick) {
+        keyClick = map?.on('click', handleMapEvent);
+      }
+
+      if (registerOnPointerMove) {
+        keyMove = map?.on('pointermove', onPointerMove);
+      }
+
+      if (registerOnPointerRest) {
+        // @ts-expect-error pointerrest is no default event
+        keyRest = map?.on('pointerrest', handleMapEvent);
+      }
+    }
 
     return () => {
-      map?.un('click', onMapClick);
+      if (keyClick) {
+        map?.un('click', keyClick.listener);
+      }
+
+      if (keyMove) {
+        map?.un('pointermove', keyMove.listener);
+      }
+
+      if (keyRest) {
+        // @ts-expect-error pointerrest is no default event
+        map?.un('pointerrest', keyRest.listener);
+      }
     };
-  }, [map, onMapClick]);
+  }, [
+    active, map, onPointerMove, handleMapEvent, registerOnClick, registerOnPointerMove, registerOnPointerRest
+  ]);
 
   // We want to propagate the state here so the variables do
   // not change on every render cycle.

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -112,6 +112,12 @@ export const useCoordinateInfo = ({
     if (_isNil(map)) {
       return;
     }
+
+    if (clickEvent === 'dblclick') {
+      // prevent map zoom on double click
+      olEvt.stopPropagation();
+    }
+
     const mapView = map.getView();
     const viewResolution = mapView.getResolution();
     const viewProjection = mapView.getProjection();
@@ -235,7 +241,7 @@ export const useCoordinateInfo = ({
     }
     setLoading(false);
 
-  }, [drillDown, featureCount, fetchOpts, getInfoFormat, layerFilter, map, onError, onSuccess]);
+  }, [clickEvent, drillDown, featureCount, fetchOpts, getInfoFormat, layerFilter, map, onError, onSuccess]);
 
   useEffect(() => {
     let keyMove: EventsKey | undefined;

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -43,6 +43,7 @@ export interface CoordinateInfoResult {
 
 export interface UseCoordinateInfoArgs {
   active: boolean;
+  clickEvent?: 'click' | 'dblclick';
   drillDown?: boolean;
   featureCount?: number;
   fetchOpts?: Record<string, RequestInit> | ((layer: WmsLayer) => RequestInit);
@@ -62,6 +63,7 @@ const getFeatureType = (feature: OlFeature) => {
 
 export const useCoordinateInfo = ({
   active,
+  clickEvent = 'click',
   drillDown = false,
   featureCount = 1,
   fetchOpts = {},
@@ -240,8 +242,8 @@ export const useCoordinateInfo = ({
     let keyRest: EventsKey | undefined;
     let keyClick: EventsKey | undefined;
     if (active) {
-      if (registerOnClick) {
-        keyClick = map?.on('click', handleMapEvent);
+      if (registerOnClick && clickEvent) {
+        keyClick = map?.on(clickEvent, handleMapEvent);
       }
 
       if (registerOnPointerMove) {
@@ -255,8 +257,8 @@ export const useCoordinateInfo = ({
     }
 
     return () => {
-      if (keyClick) {
-        map?.un('click', keyClick.listener);
+      if (keyClick && clickEvent) {
+        map?.un(clickEvent, keyClick.listener);
       }
 
       if (keyMove) {
@@ -269,7 +271,8 @@ export const useCoordinateInfo = ({
       }
     };
   }, [
-    active, map, onPointerMove, handleMapEvent, registerOnClick, registerOnPointerMove, registerOnPointerRest
+    active, map, onPointerMove, handleMapEvent, registerOnClick,
+    registerOnPointerMove, registerOnPointerRest, clickEvent
   ]);
 
   // We want to propagate the state here so the variables do

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,12 @@ export { createWfsSearchFunction } from './Hooks/search/createWfsSearchFunction'
 export {
   SearchFunction, SearchOptions, useSearch
 } from './Hooks/search/useSearch/useSearch';
+export { InkmapPrintSpec } from './Util/InkmapTypes';
+export { default as ClickAwayListener } from './Util/ClickAwayListener/ClickAwayListener';
+export { default as DigitizeUtil } from './Util/DigitizeUtil';
+export { default as PrintUtil } from './Util/PrintUtil';
 export { default as useAsyncEffect } from './Hooks/useAsyncEffect/useAsyncEffect';
+export { default as useCoordinateInfo } from './Hooks/useCoordinateInfo/useCoordinateInfo';
 export { default as useDebouncedState } from './Hooks/useDebouncedState/useDebouncedState';
 export { default as useDraw } from './Hooks/useDraw/useDraw';
 export { default as useDropTargetMap } from './Hooks/useDropTargetMap/useDropTargetMap';
@@ -23,8 +28,4 @@ export { default as usePermalink } from './Hooks/usePermalink/usePermalink';
 export { default as usePropOrDefault } from './Hooks/usePropOrDefault/usePropOrDefault';
 export { default as useSelectFeatures } from './Hooks/useSelectFeatures/useSelectFeatures';
 export { default as useTimeLayerAware } from './Hooks/useTimeLayerAware/useTimeLayerAware';
-export { default as ClickAwayListener } from './Util/ClickAwayListener/ClickAwayListener';
-export { default as DigitizeUtil } from './Util/DigitizeUtil';
-export { InkmapPrintSpec } from './Util/InkmapTypes';
-export { default as PrintUtil } from './Util/PrintUtil';
 export { zoomTo } from './Util/ZoomUtil';


### PR DESCRIPTION
This PR introduces a breaking change in the `useCoordinateInfo` hook and some new features. In particular:

* Adds `pointermove` and `pointerrest` events to map (if activated) to support mouse hover functionality
* Click event type can be passed to hook `click` | `dblclick`
* Replace `queryLayers` by a more flexible layer filter function (default: all layers are used)
before:
```
const myLayer = …
const queryLayers = [myLayer]
const results = useCoordinateInfo({
  queryLayers
});
```
  
after (exemplary) :
```
const myLayer = …
const layerFilter = (l: WmsLayer) => getUid(l) === getUid(myLayer);
const results = useCoordinateInfo({
  layerFilter
});
```
* introduce `infoFormat` as a function ➡️ herewith the supported GFI format can be determined for each layer seperately (e.g. via preconfigured property of layer oder via `GetCapabilities` request)

**BREAKING CHANGE**: queryLayers is replaced by layerFilter and fix info format by function

Table of props:

| Prop Name             | Type                                                                 | Default                | Description                                                                                       |
|-----------------------|----------------------------------------------------------------------|------------------------|---------------------------------------------------------------------------------------------------|
| `active`              | `boolean`                                                            | `undefined`            | Indicates whether the coordinate info functionality is active.                                    |
| `drillDown`           | `boolean`                                                            | `false`                | If `true`, allows drilling down through multiple layers to get feature info.                      |
| `featureCount`        | `number`                                                             | `1`                    | Specifies the number of features to fetch.                                                        |
| `fetchOpts`           | `Record<string, RequestInit>` \| `((layer: WmsLayer) => RequestInit)` | `{}`                   | Options for the fetch request, either as a record or a function returning options for each layer. |
| `getInfoFormat`       | `(layer: WmsLayer) => string \| Promise<string>`                     | `() => 'application/json'` | Function to determine the info format for a given layer.                                          |
| `layerFilter`         | `(layerCandidate: OlLayer<OlSource>) => boolean`                     | `() => true`           | Function to filter layers that should be considered for fetching feature info.                    |
| `onError`             | `(error: any) => void`                                               | `() => undefined`      | Callback function to handle errors.                                                               |
| `onSuccess`           | `(result: CoordinateInfoResult) => void`                             | `() => undefined`      | Callback function to handle successful fetching of feature info.                                  |
| `registerOnClick`     | `boolean`                                                            | `true`                 | If `true`, registers a click event listener on the map.                                           |
| `registerOnPointerMove` | `boolean`                                                          | `false`                | If `true`, registers a pointer move event listener on the map.                                    |
| `registerOnPointerRest` | `boolean`                                                          | `false`                | If `true`, registers a pointer rest event listener on the map.                                    |
| `clickEvent` | `'click' \| 'dblclick'` | `'click'` | The event name to register for click events

Plz review @terrestris/devs 