### PR TITLE
feat: added useDrawCut hook

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -23,7 +23,7 @@ const config = {
   },
   transformIgnorePatterns: [
     '<rootDir>/node_modules/(?!(ol|color-space|color-rgba|color-name|color-*[a-z]*|@camptocamp|@terrestris|quickselect|' +
-    'd3-*[a-z]*|query-string|decode-uri-component|split-on-first|filter-obj|shpjs|geostyler-openlayers-parser|geostyler-style))'
+    'd3-*[a-z]*|query-string|decode-uri-component|split-on-first|filter-obj|shpjs|geostyler-openlayers-parser|geostyler-style|jsts))'
   ],
   moduleFileExtensions: [
     'ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@camptocamp/inkmap": "^1.4.0",
         "@terrestris/base-util": "^3.0.0",
+        "jsts": "^2.12.1",
         "lodash": "^4.17.21",
         "moment": "^2.30.1"
       },
@@ -5023,6 +5024,15 @@
         "jsts": "2.7.1"
       }
     },
+    "node_modules/@turf/jsts/node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/@turf/kinks": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.2.0.tgz",
@@ -9903,6 +9913,11 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastpriorityqueue": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.7.5.tgz",
+      "integrity": "sha512-3Pa0n9gwy8yIbEsT3m2j/E9DXgWvvjfiZjjqcJ+AdNKTAlVMIuFYrYG5Y3RHEM8O6cwv9hOpOWY/NaMfywoQVA=="
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -12973,13 +12988,14 @@
       }
     },
     "node_modules/jsts": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
-      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
-      "dev": true,
-      "license": "(EDL-1.0 OR EPL-1.0)",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.12.1.tgz",
+      "integrity": "sha512-aaiCZeGfeU5o9TbrYF1KF0VvhGGLtG3w7vNynmaTjC8XRmS2v15lq+2Bxa8lMtprsFFJiIpAayJZguLruiHd0w==",
+      "dependencies": {
+        "fastpriorityqueue": "^0.7.5"
+      },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
       }
     },
     "node_modules/jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@camptocamp/inkmap": "^1.4.0",
     "@terrestris/base-util": "^3.0.0",
+    "jsts": "^2.12.1",
     "lodash": "^4.17.21",
     "moment": "^2.30.1"
   },

--- a/src/Hooks/useDrawCut/useDrawCut.ts
+++ b/src/Hooks/useDrawCut/useDrawCut.ts
@@ -1,0 +1,190 @@
+import {useCallback} from 'react';
+
+import JstsGeometry from 'jsts/org/locationtech/jts/geom/Geometry';
+import JstsMultiPolygon from 'jsts/org/locationtech/jts/geom/MultiPolygon';
+import JstsPolygon from 'jsts/org/locationtech/jts/geom/Polygon';
+import OL3Parser from 'jsts/org/locationtech/jts/io/OL3Parser';
+import BufferOp from 'jsts/org/locationtech/jts/operation/buffer/BufferOp';
+import OverlayOp from 'jsts/org/locationtech/jts/operation/overlay/OverlayOp';
+import ValidOp from 'jsts/org/locationtech/jts/operation/valid/IsValidOp';
+
+import * as OlEventConditions from 'ol/events/condition';
+import OlFeature from 'ol/Feature';
+import {
+  GeometryCollection,
+  LinearRing,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon
+} from 'ol/geom';
+
+import OlGeometry from 'ol/geom/Geometry';
+import OlInteractionDraw, {DrawEvent as OlDrawEvent} from 'ol/interaction/Draw';
+import OlVectorLayer from 'ol/layer/Vector';
+import OlSourceVector from 'ol/source/Vector';
+import {StyleLike as OlStyleLike} from 'ol/style/Style';
+
+import DigitizeUtil from '../../Util/DigitizeUtil';
+import useMap from '../useMap/useMap';
+
+import useOlInteraction from '../useOlInteraction/useOlInteraction';
+import useOlListener from '../useOlListener/useOlListener';
+import usePropOrDefault from '../usePropOrDefault/usePropOrDefault';
+
+interface UseDrawCutProps {
+  /**
+   * Active state of interaction
+   */
+  active: boolean;
+  /**
+   * Style object / style function for drawn feature.
+   */
+  drawStyle?: OlStyleLike;
+  /**
+   * The vector layer which will be used for digitize features.
+   * The standard digitizeLayer can be retrieved via `DigitizeUtil.getDigitizeLayer(map)`.
+   */
+  digitizeLayer?: OlVectorLayer<OlSourceVector>;
+  /**
+   * A function that is called before the cut is started.
+   * @param geom The cut geometry.
+   * @returns If the function returns `false` no cut will be performed.
+   */
+  onCutStart?: (geom: OlGeometry) => boolean|undefined|Promise<boolean|undefined>;
+  /**
+   * A function that is called after the cut was completed successfully.
+   * @param changed A list of changed features. The geometry is undefined if the feature was removed.
+   */
+  onCutEnd?: (changed: OlFeature[]) => void;
+}
+
+// @ts-expect-error we don't seem to need a geometry factory
+const jstsParser = new OL3Parser(undefined, undefined);
+jstsParser.inject(
+  Point,
+  LineString,
+  LinearRing,
+  Polygon,
+  MultiPoint,
+  MultiLineString,
+  MultiPolygon,
+  GeometryCollection
+);
+
+/**
+ * Tries to make an invalid geometry valid.
+ */
+const makeValid = (geom: JstsGeometry) => {
+  if (ValidOp.isValid(geom) === false) {
+    if (geom instanceof JstsPolygon || geom instanceof JstsMultiPolygon) {
+      return BufferOp.bufferOp(geom, 0);
+    } else {
+      throw new Error('Geometry is invalid, but can\'t be fixed');
+    }
+  }
+  return geom;
+};
+
+/**
+ * Cuts out the given geometry from all feature geometries in the given source. All geometries that become empty by this
+ * operation are removed from the source.
+ * It returns an array of all changed features. If the feature was removed, the geometry is set to `undefined`.
+ */
+const cut = (source: OlSourceVector, olGeom: OlGeometry): OlFeature[] => {
+  const cutGeom = makeValid(jstsParser.read(olGeom));
+
+  const changed = [];
+
+  for (const feature of source.getFeatures().slice(0)) {
+    const featureGeom = makeValid(jstsParser.read(feature.getGeometry()));
+
+    const intersection = OverlayOp.intersection(featureGeom, cutGeom);
+
+    if (!intersection || intersection.isEmpty()) {
+      continue;
+    }
+
+    const diffGeom = OverlayOp.difference(featureGeom, cutGeom);
+
+    if (diffGeom.isEmpty()) {
+      feature.setGeometry(undefined);
+      source.removeFeature(feature);
+    } else {
+      feature.setGeometry(jstsParser.write(diffGeom));
+    }
+    changed.push(feature);
+  }
+
+  return changed;
+};
+
+/**
+ * A hook that adds an interaction to cut out polygons out of existing geometries. For all geometries in the
+ * digitizeLayer the difference with a drawn polygon is calculated.
+ */
+export const useDrawCut = ({
+  active,
+  onCutEnd,
+  onCutStart,
+  digitizeLayer,
+  drawStyle
+}: UseDrawCutProps) => {
+  const map = useMap();
+
+  const layer = usePropOrDefault(
+    digitizeLayer,
+    () => map ? DigitizeUtil.getDigitizeLayer(map) : undefined,
+    [map]
+  );
+
+  const onDrawEnd = useCallback(async (e: OlDrawEvent) => {
+    const source = layer?.getSource();
+    if (!source) {
+      return;
+    }
+
+    const olGeom = e.feature.getGeometry();
+    if (!olGeom) {
+      return;
+    }
+
+    const performCut = await onCutStart?.(olGeom);
+
+    if (performCut === false) {
+      return;
+    }
+
+    const changed = cut(source, olGeom);
+    onCutEnd?.(changed);
+  }, [layer, onCutStart, onCutEnd]);
+
+  const drawInteraction = useOlInteraction(
+    () => {
+      if (!map) {
+        return undefined;
+      }
+
+      const newInteraction = new OlInteractionDraw({
+        type: 'Polygon',
+        style: drawStyle ?? DigitizeUtil.defaultDigitizeStyleFunction,
+        freehandCondition: OlEventConditions.never
+      });
+
+      newInteraction.set('name', 'react-util-draw-interaction-cutdelete');
+      return newInteraction;
+    },
+    [map, layer, drawStyle],
+    active
+  );
+
+  useOlListener(
+    drawInteraction,
+    i => i.on('drawend', onDrawEnd),
+    [drawInteraction, onDrawEnd]
+  );
+};
+
+export default useDrawCut;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { default as useAsyncEffect } from './Hooks/useAsyncEffect/useAsyncEffect
 export { default as useCoordinateInfo } from './Hooks/useCoordinateInfo/useCoordinateInfo';
 export { default as useDebouncedState } from './Hooks/useDebouncedState/useDebouncedState';
 export { default as useDraw } from './Hooks/useDraw/useDraw';
+export { default as useDrawCut } from './Hooks/useDrawCut/useDrawCut';
 export { default as useDropTargetMap } from './Hooks/useDropTargetMap/useDropTargetMap';
 export { default as useGeoLocation } from './Hooks/useGeoLocation/useGeoLocation';
 export { default as useMap } from './Hooks/useMap/useMap';


### PR DESCRIPTION
This adds a hook for a draw cut interaction. It let's you draw a polygon and all features in the digitizeLayer are tested for intersection and a difference between the feature and the drawn polygon is calculated if that's the case.

A possibility to abort the cut is implemented via the return value of the `onCutStart` callback.

All involved polygons will be 'made valid` by applying a buffer of size 0.

It uses jsts which is a new dependency.

See the related react-geo PR to see how it is used.