### PR TITLE
Fix coordinateInfo issues 

### DIFF
--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -36,7 +36,7 @@ import useOlListener from '../useOlListener/useOlListener';
 
 export interface FeatureLayerResult {
   feature: OlFeature;
-  layer: WmsLayer|WmtsLayer|WfsLayer;
+  layer: WmsLayer | WmtsLayer | WfsLayer;
   featureType: string;
 }
 
@@ -104,42 +104,49 @@ export const useCoordinateInfo = ({
     [mapView]
   );
 
-  const wmsMapLayers = useMemo(() => {
+  const wmsMapLayerUids = useMemo(() => {
     if (_isNil(map) || _isNil(pixelCoordinate)) {
       return [];
     }
     return map.getAllLayers()
       .reverse()
       .filter(layerFilter)
-      .filter(l => l.getData && l.getData(pixelCoordinate) && isWmsLayer(l)) as WmsLayer[];
+      .filter(l => l.getData && l.getData(pixelCoordinate) && isWmsLayer(l))
+      .map(getUid);
   }, [layerFilter, map, pixelCoordinate]);
 
-  const wmtsMapLayers = useMemo(() => {
+  const wmtsMapLayerUids = useMemo(() => {
     if (_isNil(map) || _isNil(pixelCoordinate)) {
       return [];
     }
     return map.getAllLayers()
       .reverse()
       .filter(layerFilter)
-      .filter(l => isWmtsLayer(l)) as WmtsLayer[];
+      .filter(l => isWmtsLayer(l))
+      .map(getUid);
   }, [layerFilter, map, pixelCoordinate]);
 
-  const wfsMapLayers = useMemo(() => {
+  const wfsMapLayerUids = useMemo(() => {
     if (_isNil(map) || _isNil(pixelCoordinate)) {
       return [];
     }
     return map.getAllLayers()
       .reverse()
       .filter(layerFilter)
-      .filter(l => isWfsLayer(l)) as WfsLayer[];
+      .filter(l => isWfsLayer(l))
+      .map(getUid);
   }, [layerFilter, map, pixelCoordinate]);
 
-  const orderedLayers = useMemo(() => {
+  const orderedLayerUids = useMemo(() => {
     if (_isNil(map)) {
-      return [];
+      return new Set<string>();
     }
     const all = map.getAllLayers().reverse();
-    const relevantLayers = [...wfsMapLayers, ...wmtsMapLayers, ...wmsMapLayers];
+    const relevantLayers = map.getAllLayers()
+      .filter(l => {
+        const uid = getUid(l);
+        return wfsMapLayerUids.includes(uid) || wmtsMapLayerUids.includes(uid) || wmsMapLayerUids.includes(uid);
+      });
 
     relevantLayers.sort((a, b) => {
       if (_isNil(a) || _isNil(b)) {
@@ -152,9 +159,8 @@ export const useCoordinateInfo = ({
       return aIndex - bIndex;
     });
 
-    // todo: migrate to set of uids to avoid hook issues when relevantLayers change
-    return relevantLayers;
-  }, [map, wfsMapLayers, wmtsMapLayers, wmsMapLayers]);
+    return new Set(relevantLayers.map(l => getUid(l)));
+  }, [map, wfsMapLayerUids, wmtsMapLayerUids, wmsMapLayerUids]);
 
   /**
    * Event handler for pointer move events on the map.
@@ -264,14 +270,18 @@ export const useCoordinateInfo = ({
     }
 
     const results: FeatureLayerResult[] = [];
-    const layers = useWms ? wmsMapLayers : wmtsMapLayers;
+    const layerUids = useWms ? wmsMapLayerUids : wmtsMapLayerUids;
 
-    for (const layer of layers) {
+    for (const layerId of layerUids) {
       try {
-        const layerId = getUid(layer);
         const abortController = abortControllers.current.get(layerId);
 
         if (! abortController) {
+          continue;
+        }
+
+        const layer = map.getAllLayers().find(l => getUid(l) === layerId) as WmsLayer | WmtsLayer | undefined;
+        if (!layer) {
           continue;
         }
 
@@ -316,7 +326,7 @@ export const useCoordinateInfo = ({
           if (fetchOpts instanceof Function) {
             opts = fetchOpts(layer);
           } else {
-            opts = fetchOpts[getUid(layer)];
+            opts = fetchOpts[layerId];
           }
 
           const response = await fetch(featureInfoUrl, {
@@ -349,7 +359,7 @@ export const useCoordinateInfo = ({
     }
 
     return results;
-  }, [map, viewResolution, viewProjection, wmsMapLayers, wmtsMapLayers,
+  }, [map, viewResolution, viewProjection, wmsMapLayerUids, wmtsMapLayerUids,
     getInfoFormat, featureCount, fetchOpts, drillDown]);
 
   const getResultsFromWfsLayers = useCallback(async (
@@ -361,9 +371,14 @@ export const useCoordinateInfo = ({
 
     const results: FeatureLayerResult[] = [];
 
-    for (const layer of wfsMapLayers) {
+    for (const layerId of wfsMapLayerUids) {
       if (! drillDown && results.length > 0) {
         break;
+      }
+
+      const layer = map.getAllLayers().find(l => getUid(l) === layerId) as WfsLayer | undefined;
+      if (!layer) {
+        continue;
       }
 
       const wfsLayerSource = layer.getSource();
@@ -379,7 +394,7 @@ export const useCoordinateInfo = ({
     }
 
     return results;
-  }, [map, viewProjection, wfsMapLayers, drillDown]);
+  }, [map, viewProjection, wfsMapLayerUids, drillDown]);
 
   /**
    * Event handler for map events (click, double-click, pointer rest) that retrieves the coordinate of the
@@ -422,7 +437,7 @@ export const useCoordinateInfo = ({
       return;
     }
 
-    if (_isNil(mapCoordinate) || _isNil(map) || orderedLayers?.length === 0) {
+    if (_isNil(mapCoordinate) || _isNil(map) || orderedLayerUids?.size === 0) {
       return;
     }
 
@@ -433,10 +448,9 @@ export const useCoordinateInfo = ({
     abortControllers.current.forEach(controller => controller.abort());
     abortControllers.current.clear();
 
-    orderedLayers.forEach(layer => {
-      const layerId = getUid(layer);
+    orderedLayerUids.forEach(uid => {
       const abortController = new AbortController();
-      abortControllers.current.set(layerId, abortController);
+      abortControllers.current.set(uid, abortController);
     });
 
     const fetchFeatures = async () => {
@@ -445,8 +459,15 @@ export const useCoordinateInfo = ({
         setFeatureResults(undefined);
 
         const promises: Promise<FeatureLayerResult[]>[] = [];
+        const allRelevantLayerUids = [...wfsMapLayerUids, ...wmtsMapLayerUids, ...wmsMapLayerUids];
 
-        for (const layer of orderedLayers) {
+        for (const uid of orderedLayerUids) {
+          const layerId = allRelevantLayerUids.find(id => id === uid);
+          const layer = map.getAllLayers().find(l => getUid(l) === layerId);
+
+          if (!layer) {
+            continue;
+          }
           if (isWmsLayer(layer)) {
             promises.push(getResultsFromImageLayers(mapCoordinate, true));
           } else if (isWmtsLayer(layer)) {
@@ -454,7 +475,6 @@ export const useCoordinateInfo = ({
           } else if (isWfsLayer(layer)) {
             promises.push(getResultsFromWfsLayers(mapCoordinate));
           }
-
           if (!drillDown) {
             break;
           }
@@ -487,8 +507,8 @@ export const useCoordinateInfo = ({
     });
 
   }, [
-    mapCoordinate, drillDown, featureResults, getResultsFromImageLayers, getResultsFromWfsLayers, map, orderedLayers,
-    onError, onSuccess, loading
+    mapCoordinate, drillDown, featureResults, getResultsFromImageLayers, getResultsFromWfsLayers, map, orderedLayerUids,
+    onError, onSuccess, loading, wfsMapLayerUids, wmsMapLayerUids, wmtsMapLayerUids
   ]);
 
   /**

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -139,7 +139,7 @@ export const useCoordinateInfo = ({
 
   const orderedLayerUids = useMemo(() => {
     if (_isNil(map)) {
-      return new Set<string>();
+      return [];
     }
     const all = map.getAllLayers().reverse();
     const relevantLayers = map.getAllLayers()
@@ -159,7 +159,7 @@ export const useCoordinateInfo = ({
       return aIndex - bIndex;
     });
 
-    return new Set(relevantLayers.map(getUid));
+    return relevantLayers.map(getUid);
   }, [map, wfsMapLayerUids, wmtsMapLayerUids, wmsMapLayerUids]);
 
   /**
@@ -437,7 +437,7 @@ export const useCoordinateInfo = ({
       return;
     }
 
-    if (_isNil(mapCoordinate) || _isNil(map) || orderedLayerUids?.size === 0) {
+    if (_isNil(mapCoordinate) || _isNil(map) || orderedLayerUids?.length === 0) {
       return;
     }
 
@@ -475,16 +475,20 @@ export const useCoordinateInfo = ({
           } else if (isWfsLayer(layer)) {
             promises.push(getResultsFromWfsLayers(mapCoordinate));
           }
-          if (!drillDown) {
-            break;
-          }
         }
 
-        let allResults: FeatureLayerResult[][];
-        if (drillDown) {
-          allResults = await Promise.all(promises);
-        } else {
-          const firstResult = await Promise.race(promises);
+        let allResults: FeatureLayerResult[][] = await Promise.all(promises);
+        allResults = await Promise.all(promises);
+
+        if (!drillDown) {
+          // filter empty results, order by layer index and return the first layer found
+          const firstResult = allResults
+            .filter(r => r.length > 0)
+            .sort((a, b) => {
+              const aIdx = orderedLayerUids.indexOf(getUid(a[0].layer));
+              const bIdx = orderedLayerUids.indexOf(getUid(b[0].layer));
+              return aIdx - bIdx;
+            })[0] ?? [];
           allResults = [firstResult];
         }
 

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -409,13 +409,13 @@ export const useCoordinateInfo = ({
   }, [clickEvent, map, viewProjection, viewResolution]);
 
   /**
-   * Resets featureResults when clickCoordinate changes (drilldown) OR when pixelCoordinate changes (hover).
+   * Resets featureResults when mapCoordinate changes.
    */
   useEffect(() => {
     if (!_isNil(mapCoordinate)) {
       setFeatureResults(undefined);
     }
-  }, [mapCoordinate, pixelCoordinate, drillDown]);
+  }, [mapCoordinate]);
 
   useEffect(() => {
     if (loading) {

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -159,7 +159,7 @@ export const useCoordinateInfo = ({
       return aIndex - bIndex;
     });
 
-    return new Set(relevantLayers.map(l => getUid(l)));
+    return new Set(relevantLayers.map(getUid));
   }, [map, wfsMapLayerUids, wmtsMapLayerUids, wmsMapLayerUids]);
 
   /**

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -83,7 +83,7 @@ export const useCoordinateInfo = ({
 
   const map = useMap();
 
-  const [clickCoordinate, setClickCoordinate] = useState<OlCoordinate | undefined>();
+  const [mapCoordinate, setMapCoordinate] = useState<OlCoordinate | undefined>();
   const [pixelCoordinate, setPixelCoordinate] = useState<OlPixel | undefined>();
   const [featureResults, setFeatureResults] = useState<FeatureLayerResult[] | undefined>();
   const [loading, setLoading] = useState<boolean>(false);
@@ -142,6 +142,8 @@ export const useCoordinateInfo = ({
       return aIndex - bIndex;
     });
 
+    // todo: migrate to set of uids to avoid hook issues when relevantLayers change
+    // return relevantLayers.map(l => getUid(l));
     return relevantLayers;
   }, [map, wfsMapLayers, wmtsMapLayers, wmsMapLayers]);
 
@@ -393,18 +395,25 @@ export const useCoordinateInfo = ({
 
     const clonedCoordinate = _cloneDeep(coordinate);
     const clonedPixelCoordinate = _cloneDeep(evtPixelCoordinate ?? pixel);
-    setClickCoordinate(clonedCoordinate);
+    setMapCoordinate(clonedCoordinate);
     setPixelCoordinate(clonedPixelCoordinate);
   }, [clickEvent, map, viewProjection, viewResolution]);
 
+  /**
+   * Resets featureResults when clickCoordinate changes (drilldown) OR when pixelCoordinate changes (hover).
+   */
   useEffect(() => {
-    if (!_isNil(clickCoordinate)) {
+    if (!_isNil(mapCoordinate)) {
       setFeatureResults(undefined);
     }
-  }, [clickCoordinate]);
+  }, [mapCoordinate, pixelCoordinate, drillDown]);
 
   useEffect(() => {
-    if (_isNil(clickCoordinate) || _isNil(map) || orderedLayers?.length === 0) {
+    if (loading) {
+      return;
+    }
+
+    if (_isNil(mapCoordinate) || _isNil(map) || orderedLayers?.length === 0) {
       return;
     }
 
@@ -418,22 +427,23 @@ export const useCoordinateInfo = ({
     orderedLayers.forEach(layer => {
       const layerId = getUid(layer);
       const abortController = new AbortController();
-      abortControllers. current.set(layerId, abortController);
+      abortControllers.current.set(layerId, abortController);
     });
 
     const fetchFeatures = async () => {
       try {
         setLoading(true);
+        setFeatureResults(undefined);
 
         const promises: Promise<FeatureLayerResult[]>[] = [];
 
         for (const layer of orderedLayers) {
           if (isWmsLayer(layer)) {
-            promises.push(getResultsFromImageLayers(clickCoordinate, true));
+            promises.push(getResultsFromImageLayers(mapCoordinate, true));
           } else if (isWmtsLayer(layer)) {
-            promises.push(getResultsFromImageLayers(clickCoordinate, false));
+            promises.push(getResultsFromImageLayers(mapCoordinate, false));
           } else if (isWfsLayer(layer)) {
-            promises.push(getResultsFromWfsLayers(clickCoordinate));
+            promises.push(getResultsFromWfsLayers(mapCoordinate));
           }
 
           if (!drillDown) {
@@ -468,10 +478,13 @@ export const useCoordinateInfo = ({
     });
 
   }, [
-    clickCoordinate, drillDown, featureResults, getResultsFromImageLayers, getResultsFromWfsLayers, map, orderedLayers,
-    onError, onSuccess
+    mapCoordinate, drillDown, featureResults, getResultsFromImageLayers, getResultsFromWfsLayers, map, orderedLayers,
+    onError, onSuccess, loading
   ]);
 
+  /**
+   * (Re)creates map event listeners whenever relevant props change (active, drilldown, clickEvent).
+   */
   useEffect(() => {
     let keyMove: EventsKey | undefined;
     let keyRest: EventsKey | undefined;
@@ -481,11 +494,11 @@ export const useCoordinateInfo = ({
         keyClick = map?.on(clickEvent, handleMapEvent);
       }
 
-      if (registerOnPointerMove) {
+      if (registerOnPointerMove && !drillDown) {
         keyMove = map?.on('pointermove', onPointerMove);
       }
 
-      if (registerOnPointerRest) {
+      if (registerOnPointerRest && !drillDown) {
         // @ts-expect-error pointerrest is no default event
         keyRest = map?.on('pointerrest', handleMapEvent);
       }
@@ -507,7 +520,7 @@ export const useCoordinateInfo = ({
     };
   }, [
     active, map, onPointerMove, handleMapEvent, registerOnClick,
-    registerOnPointerMove, registerOnPointerRest, clickEvent
+    registerOnPointerMove, registerOnPointerRest, clickEvent, drillDown
   ]);
 
   useEffect(() => {
@@ -518,6 +531,9 @@ export const useCoordinateInfo = ({
     };
   }, [viewResolution]);
 
+  /**
+   * Update mouse cursor when GFI is loading.
+   */
   useEffect(() => {
     if (_isNil(map)) {
       return;
@@ -528,7 +544,7 @@ export const useCoordinateInfo = ({
   // We want to propagate the state here so the variables do
   // not change on every render cycle.
   return {
-    clickCoordinate,
+    clickCoordinate: mapCoordinate,
     features: featureResults,
     loading,
     pixelCoordinate

--- a/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
+++ b/src/Hooks/useCoordinateInfo/useCoordinateInfo.ts
@@ -32,6 +32,7 @@ import {
 } from '@terrestris/ol-util';
 
 import useMap from '../useMap/useMap';
+import useOlListener from '../useOlListener/useOlListener';
 
 export interface FeatureLayerResult {
   feature: OlFeature;
@@ -83,16 +84,25 @@ export const useCoordinateInfo = ({
 
   const map = useMap();
 
+  const mapView = useMemo(() => map?.getView(), [map]);
+
   const [mapCoordinate, setMapCoordinate] = useState<OlCoordinate | undefined>();
   const [pixelCoordinate, setPixelCoordinate] = useState<OlPixel | undefined>();
   const [featureResults, setFeatureResults] = useState<FeatureLayerResult[] | undefined>();
   const [loading, setLoading] = useState<boolean>(false);
+  const [viewResolution, setViewResolution] = useState<number | undefined>(mapView?.getResolution());
 
   const abortControllers = useRef<Map<string, AbortController>>(new Map());
 
-  const mapView = useMemo(() => map?.getView(), [map]);
-  const viewResolution = useMemo(() => mapView?.getResolution(), [mapView]);
   const viewProjection = useMemo(() => mapView?.getProjection(), [mapView]);
+
+  useOlListener(
+    mapView,
+    v => v.on('change:resolution', () => {
+      setViewResolution(v.getResolution());
+    }),
+    [mapView]
+  );
 
   const wmsMapLayers = useMemo(() => {
     if (_isNil(map) || _isNil(pixelCoordinate)) {
@@ -143,7 +153,6 @@ export const useCoordinateInfo = ({
     });
 
     // todo: migrate to set of uids to avoid hook issues when relevantLayers change
-    // return relevantLayers.map(l => getUid(l));
     return relevantLayers;
   }, [map, wfsMapLayers, wmtsMapLayers, wmsMapLayers]);
 


### PR DESCRIPTION
- prevent duplicated requests: only requests GetFeatureInfo if state is not loading already
- fix resolution calculation: use useOlListener to update `viewResolution` instead of using useMemo 
  - useMemo did not work here because the OpenLayers `view` is a class instance which does not work in hook dependencies)
- refactors `orderedLayers` to a list of uuids in https://github.com/terrestris/react-util/commit/f9176266fb105058c4ecd3649d997426fdab920f.

@terrestris/devs Please review.